### PR TITLE
Remove Hugo Book theme to use custom layout

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,7 +1,7 @@
 baseURL = "https://wooa.dev/"
 languageCode = "ko-kr"
 title = "WOOA.DEV"
-theme = "hugo-book"
+# theme = "hugo-book"  # Using custom layout instead
 
 enableRobotsTXT = true
 enableEmoji = true
@@ -17,12 +17,8 @@ pygmentsCodeFences = true
   description = "인프라 · 리눅스 · 보안 실무 기록"
   # profileImage = "/images/profile.png"  # 프로필 이미지 경로 (선택사항)
 
-  # Book theme settings
-  BookTheme = "auto"
-  BookToC = true
-  BookSection = "docs"
-  BookRepo = "https://github.com/devwooops/wooa.dev"
-  BookEditPath = "edit/main"
+  # Theme settings
+  defaultTheme = "auto"  # auto, light, dark
 
   # Custom settings
   recentPostsCount = 5
@@ -35,8 +31,9 @@ pygmentsCodeFences = true
     theme = "github-light"
     darkTheme = "github-dark"
 
-[params.BookSearch]
-  enabled = true
+  # Search
+  [params.search]
+    enabled = true
 
 # Social links
 [[params.social]]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.LanguageCode }}" data-theme="{{ .Site.Params.BookTheme }}">
+<html lang="{{ .Site.LanguageCode }}" data-theme="{{ .Site.Params.defaultTheme | default "auto" }}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -9,14 +9,12 @@
 
     <title>{{ if .IsHome }}{{ .Site.Title }}{{ else }}{{ .Title }} | {{ .Site.Title }}{{ end }}</title>
 
-    {{- if .Site.Params.BookTheme }}
     <script>
         (function() {
-            const theme = localStorage.getItem('theme') || '{{ .Site.Params.BookTheme }}';
+            const theme = localStorage.getItem('theme') || '{{ .Site.Params.defaultTheme | default "auto" }}';
             document.documentElement.dataset.theme = theme;
         })();
     </script>
-    {{- end }}
 
     {{- partial "head.html" . -}}
 </head>

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -48,7 +48,7 @@
     <!-- Search -->
     <div class="sidebar-search">
         <h3 class="sidebar-title">{{ .Site.Title }}</h3>
-        {{- if .Site.Params.BookSearch.enabled }}
+        {{- if .Site.Params.search.enabled }}
         <form action="/search" method="get" class="search-form">
             <input type="search" name="q" placeholder="검색..." class="search-input" aria-label="Search">
             <button type="submit" class="search-button" aria-label="Submit Search">


### PR DESCRIPTION
- Disabled hugo-book theme (was causing CSS conflicts)
- Updated theme configuration parameters:
  - BookTheme → defaultTheme
  - BookSearch → search
- Updated templates to use new parameter names
- This should fix the layout issues caused by theme CSS conflicts

The custom 3-column layout should now display correctly without interference from the Book theme's default styles.